### PR TITLE
[OC-52] Templates version packaged

### DIFF
--- a/packages/oc-template-handlebars-compiler/lib/compile.js
+++ b/packages/oc-template-handlebars-compiler/lib/compile.js
@@ -6,6 +6,7 @@ const compileServer = require('./compileServer');
 const compileStatics = require('./compileStatics');
 const compileView = require('./compileView');
 const fs = require('fs-extra');
+const getInfo = require('oc-template-handlebars').getInfo;
 const getUnixUtcTimestamp = require('oc-get-unix-utc-timestamp');
 const path = require('path');
 
@@ -56,6 +57,7 @@ module.exports = (options, callback) => {
       },
       // Compile package.json
       function(componentPackage, cb) {
+        componentPackage.oc.files.template.version = getInfo().version;
         componentPackage.oc.version = ocPackage.version;
         componentPackage.oc.packaged = true;
         componentPackage.oc.date = getUnixUtcTimestamp();

--- a/packages/oc-template-handlebars-compiler/test/__snapshots__/compile.test.js.snap
+++ b/packages/oc-template-handlebars-compiler/test/__snapshots__/compile.test.js.snap
@@ -22,6 +22,7 @@ Object {
         "hashKey": "2112a7cce970d8e5eb8a60c5ada1c4d822b22b0e",
         "src": "template.js",
         "type": "handlebars",
+        "version": "6.0.1",
       },
     },
     "packaged": true,

--- a/packages/oc-template-jade-compiler/lib/compile.js
+++ b/packages/oc-template-jade-compiler/lib/compile.js
@@ -6,6 +6,7 @@ const compileServer = require('./compileServer');
 const compileStatics = require('./compileStatics');
 const compileView = require('./compileView');
 const fs = require('fs-extra');
+const getInfo = require('oc-template-jade').getInfo;
 const getUnixUtcTimestamp = require('oc-get-unix-utc-timestamp');
 const path = require('path');
 
@@ -56,6 +57,7 @@ module.exports = (options, callback) => {
       },
       // Compile package.json
       function(componentPackage, cb) {
+        componentPackage.oc.files.template.version = getInfo().version;
         componentPackage.oc.version = ocPackage.version;
         componentPackage.oc.packaged = true;
         componentPackage.oc.date = getUnixUtcTimestamp();

--- a/packages/oc-template-jade-compiler/test/__snapshots__/compile.test.js.snap
+++ b/packages/oc-template-jade-compiler/test/__snapshots__/compile.test.js.snap
@@ -22,6 +22,7 @@ Object {
         "hashKey": "096e8ec0a00c37c4bd669e2ad046892d93766ff0",
         "src": "template.js",
         "type": "jade",
+        "version": "6.0.1",
       },
     },
     "packaged": true,


### PR DESCRIPTION
When packaging the component add exact template (not the compiler) version info that might be needed for rendering.