### PR TITLE
Include scaffold src files with distributions

### DIFF
--- a/packages/oc-template-handlebars-compiler/package.json
+++ b/packages/oc-template-handlebars-compiler/package.json
@@ -39,6 +39,7 @@
   },
   "files": [
     "index.js",
-    "lib"
+    "lib",
+    "scaffold"
   ]
 }

--- a/packages/oc-template-jade-compiler/package.json
+++ b/packages/oc-template-jade-compiler/package.json
@@ -42,6 +42,7 @@
   },
   "files": [
     "index.js",
-    "lib"
+    "lib",
+    "scaffold"
   ]
 }


### PR DESCRIPTION
With the latest work on the scaffold src files, we forgot to make sure we include those files with the distributions. This should fix it.