### PR TITLE
Semantic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,11 @@ matrix:
 after_script:
   - npm run coverage
 
+script:
+  - validate-commit-msg "$(git log -1 --pretty=%B)" && npm test
+
 notifications:
   email: false
+
+before_install: ".travis/before_install.sh"
+after_success: ".travis/after_success.sh"

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  npm run coverage
-fi
-
 if [ $TRAVIS_BRANCH == 'master' ]; then
   if [ $TRAVIS_NODE_VERSION == '6' ]; then
     npm run semantic-release

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  npm run coverage
+fi
+
+if [ $TRAVIS_BRANCH == 'master' ]; then
+  if [ $TRAVIS_NODE_VERSION == '6' ]; then
+    npm run semantic-release
+  fi
+fi

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+# Note: do not do set -x or the passwords will leak!
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "We are in a pull request, not setting up release"
+  exit 0
+fi
+
+if [ $TRAVIS_BRANCH == 'master' ]; then
+  if [ $TRAVIS_NODE_VERSION == '6' ]; then
+    rm -rf .git
+    git init
+    git clean -dfx
+    git remote add origin https://github.com/$TRAVIS_REPO_SLUG.git
+    git fetch origin
+    git clone https://github.com/$TRAVIS_REPO_SLUG.git $TRAVIS_REPO_SLUG
+    git checkout $TRAVIS_BRANCH
+
+    git config credential.helper store
+    echo "https://${RELEASE_GH_USERNAME}:${RELEASE_GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" > ~/.git-credentials
+
+    npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN -q
+    npm prune
+
+    git config --global user.email "oc@opentable.com"
+    git config --global user.name "OpenComponents Team"
+    git config --global push.default simple
+
+    git fetch --tags
+    git branch -u origin/$TRAVIS_BRANCH
+    git fsck --full #debug
+    echo "npm whoami"
+    npm whoami #debug
+    echo "git config --list"
+    git config --list #debug
+  fi
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+First of all, thank you for contributing. It’s appreciated.
+
+# To submit a pull request
+
+1. Open a GitHub issue before doing significant amount of work.
+2. Clone the repo. If it was already cloned, then git pull to get the latest from master.
+3. Run `npm install` before anything else, and wait.
+6. Write code.
+7. Write test (coverage regressions will fail the build). Run test with `npm test`. 
+8. Commit using `npm run commit` and follow the CLI instructions.
+9. Make a pull request against the master branch.
+
+# To release new versions
+
+1. We run on semantic-release, meaaning that the right version for each package will be automatically published upon succesful merge to master.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ base-templates
 
 [![Build Status](https://travis-ci.org/opencomponents/base-templates.svg?branch=master)](https://travis-ci.org/opencomponents/base-templates)
 [![codecov](https://codecov.io/gh/opencomponents/base-templates/branch/master/graph/badge.svg)](https://codecov.io/gh/opencomponents/base-templates)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/atlassian/lerna-semantic-release)
 
 This is a monorepo including the [OpenComponents](https://github.com/opentable/oc) base-templates:
 

--- a/package.json
+++ b/package.json
@@ -1,18 +1,25 @@
 {
   "devDependencies": {
     "codecov": "^2.2.0",
+    "commitizen": "^2.9.6",
+    "cz-lerna-changelog": "^1.2.1",
     "husky": "^0.13.4",
     "jest": "^20.0.4",
     "lerna": "^2.0.0-rc.5",
+    "lerna-semantic-release": "^9.1.0",
     "lint-staged": "^3.6.0",
-    "prettier-eslint-cli": "^4.0.4"
+    "prettier-eslint-cli": "^4.0.4",
+    "validate-commit-msg": "2.13.0"
   },
   "scripts": {
     "postinstall": "lerna bootstrap",
     "clean": "lerna clean",
     "coverage": "codecov",
     "test": "jest",
-    "publish": "lerna publish --exact",
+    "semantic-release": "lerna-semantic-release pre && lerna-semantic-release post && lerna-semantic-release perform",
+    "changelog": "lerna-semantic-release post",
+    "commitmsg": "validate-commit-msg",
+    "commit": "git-cz",
     "precommit": "lint-staged"
   },
   "lint-staged": {
@@ -22,7 +29,21 @@
       "git add"
     ]
   },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-lerna-changelog"
+    },
+    "validate-commit-msg": {
+      "scope": {
+        "required": false,
+        "validate": false,
+        "multiple": true
+      },
+      "helpMessage": "Please execute `npm run commit` to generate a correct commit message"
+    }
+  },
   "jest": {
+    "rootDir": "packages",
     "coverageDirectory": "./coverage/",
     "collectCoverage": true
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lerna-semantic-release": "^9.1.0",
     "lint-staged": "^3.6.0",
     "prettier-eslint-cli": "^4.0.4",
-    "validate-commit-msg": "2.13.0"
+    "validate-commit-msg": "^2.13.1"
   },
   "scripts": {
     "postinstall": "lerna bootstrap",


### PR DESCRIPTION
This is a follow-up attempt on https://github.com/opencomponents/base-templates/pull/33 

Differences are
- Release triggered only from a specific travis node version test (As travis doesn't support otherwise yet) - picked the lowest within our matrix (node 6)
- Jest rootDir config allow to specify where jest will look for tests, this fixes the issues that was causing the previous PR to fail.
- Some minor improvements/cleanup.

Related PRs (already merged and this PR has been updated):
- I've noticed that the latest release of `validate-commit-msg` introduce a bug where the CLI doesn't exit properly (1) in case of errors upon validation, meaning that validate-commit-msg won't be able to brake the build. I've fixed the issue and opened a pr -> https://github.com/conventional-changelog/validate-commit-msg/pull/104 . 
- [x] Updated `validate-commit-msg` version once the above fix has been published