### PR TITLE
test: removed version from snapshots

### DIFF
--- a/packages/oc-template-handlebars-compiler/test/__snapshots__/compile.test.js.snap
+++ b/packages/oc-template-handlebars-compiler/test/__snapshots__/compile.test.js.snap
@@ -22,7 +22,7 @@ Object {
         "hashKey": "2112a7cce970d8e5eb8a60c5ada1c4d822b22b0e",
         "src": "template.js",
         "type": "handlebars",
-        "version": "6.0.1",
+        "version": "",
       },
     },
     "packaged": true,

--- a/packages/oc-template-handlebars-compiler/test/compile.test.js
+++ b/packages/oc-template-handlebars-compiler/test/compile.test.js
@@ -10,6 +10,7 @@ const componentPath = path.join(
   __dirname,
   '../../../mocks/handlebars-component/'
 );
+const getInfo = require('../index.js').getInfo;
 const publishPath = path.join(componentPath, '__package');
 
 test('Should correctly compile the oc component', done => {
@@ -24,8 +25,11 @@ test('Should correctly compile the oc component', done => {
   fs.ensureDirSync(publishPath);
   compile(options, (err, res) => {
     expect(err).toBeNull();
+    const version = res.oc.files.template.version;
+    res.oc.files.template.version = '';
     res.oc.date = '';
     expect(res).toMatchSnapshot();
+    expect(version).toBe(getInfo().version);
     nodeDir.paths(publishPath, (err, res) => {
       const files = res.files
         .map(filePath => path.relative(__dirname, filePath))

--- a/packages/oc-template-jade-compiler/test/__snapshots__/compile.test.js.snap
+++ b/packages/oc-template-jade-compiler/test/__snapshots__/compile.test.js.snap
@@ -22,7 +22,7 @@ Object {
         "hashKey": "096e8ec0a00c37c4bd669e2ad046892d93766ff0",
         "src": "template.js",
         "type": "jade",
-        "version": "6.0.1",
+        "version": "",
       },
     },
     "packaged": true,

--- a/packages/oc-template-jade-compiler/test/compile.test.js
+++ b/packages/oc-template-jade-compiler/test/compile.test.js
@@ -7,6 +7,7 @@ const nodeDir = require('node-dir');
 
 const componentPackage = require('../../../mocks/jade-component/package.json');
 const componentPath = path.join(__dirname, '../../../mocks/jade-component/');
+const getInfo = require('../index.js').getInfo;
 const publishPath = path.join(componentPath, '__package');
 
 test('Should correctly compile the oc component', done => {
@@ -21,8 +22,11 @@ test('Should correctly compile the oc component', done => {
   fs.ensureDirSync(publishPath);
   compile(options, (err, res) => {
     expect(err).toBeNull();
+    const version = res.oc.files.template.version;
+    res.oc.files.template.version = '';
     res.oc.date = '';
     expect(res).toMatchSnapshot();
+    expect(version).toBe(getInfo().version);
     nodeDir.paths(publishPath, (err, res) => {
       const files = res.files
         .map(filePath => path.relative(__dirname, filePath))


### PR DESCRIPTION
affects: oc-template-handlebars-compiler, oc-template-jade-compiler

This remove the specific version being added to the snapshot so that tests don't brakes for new
releases