### PR TITLE
oc-weback compiler fix

### DIFF
--- a/packages/oc-minify-file/index.js
+++ b/packages/oc-minify-file/index.js
@@ -31,4 +31,5 @@ module.exports = function(fileExtension, fileContent) {
 
     return result.styles;
   }
+  // comment
 };

--- a/packages/oc-minify-file/index.js
+++ b/packages/oc-minify-file/index.js
@@ -31,5 +31,4 @@ module.exports = function(fileExtension, fileContent) {
 
     return result.styles;
   }
-  // comment
 };

--- a/packages/oc-webpack/lib/compiler/index.js
+++ b/packages/oc-webpack/lib/compiler/index.js
@@ -39,7 +39,7 @@ module.exports = function compiler(config, callback) {
     }
 
     const serverContentBundled = memoryFs.readFileSync(
-      '/build/server.js',
+      `/build/${config.output.filename}`,
       'UTF8'
     );
     callback(null, serverContentBundled);


### PR DESCRIPTION
This allow the oc-webpack compiler to also used for non-server compilation