### PR TITLE
fix: referencing the published version

### DIFF
--- a/packages/oc-template-handlebars/package.json
+++ b/packages/oc-template-handlebars/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "handlebars": "4.0.6",
-    "oc-generic-template-renderer": "^1.0.0",
+    "oc-generic-template-renderer": "^2.0.0",
     "oc-templates-messages": "^1.0.1"
   },
   "files": [

--- a/packages/oc-template-jade/package.json
+++ b/packages/oc-template-jade/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "jade-legacy": "1.11.1",
-    "oc-generic-template-renderer": "^1.0.0"
+    "oc-generic-template-renderer": "^2.0.0"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
affects: oc-template-handlebars, oc-template-jade