### PR TITLE
fix: destructuring will make the oc-client-node unable to be green wi…

### DIFF
--- a/packages/oc-generic-template-renderer/lib/getCompiledTemplate.js
+++ b/packages/oc-generic-template-renderer/lib/getCompiledTemplate.js
@@ -1,7 +1,7 @@
 const vm = require('vm');
 
-module.exports = (templateString, key) => {
-  const context = {};
+module.exports = (templateString, key, context) => {
+  context = context || {};
   vm.runInNewContext(templateString, context);
   return context.oc.components[key];
 };

--- a/packages/oc-template-handlebars/index.js
+++ b/packages/oc-template-handlebars/index.js
@@ -1,16 +1,13 @@
 'use strict';
 
-const {
-  getCompiledTemplate,
-  getInfo
-} = require('oc-generic-template-renderer');
 const packageJson = require('./package.json');
 const render = require('./lib/render');
+const renderer = require('oc-generic-template-renderer');
 
 module.exports = {
   getInfo() {
-    return getInfo(packageJson);
+    return renderer.getInfo(packageJson);
   },
-  getCompiledTemplate,
+  getCompiledTemplate: renderer.getCompiledTemplate,
   render
 };

--- a/packages/oc-template-handlebars/test/getCompiledTemplate.test.js
+++ b/packages/oc-template-handlebars/test/getCompiledTemplate.test.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { getCompiledTemplate } = require('../index.js');
+const getCompiledTemplate = require('../').getCompiledTemplate;
 
 test('Return compiled template when valid', () => {
   const template =

--- a/packages/oc-template-handlebars/test/render.test.js
+++ b/packages/oc-template-handlebars/test/render.test.js
@@ -1,6 +1,24 @@
 const render = require('../lib/render');
 
 describe('render method', () => {
+  describe('when invoked with a invalid template', () => {
+    const model = { aModel: true };
+    const template = {
+      compiler: [6, '>= 3.0.0'],
+      main: function() {
+        return 'Hello world!';
+      },
+      useData: !0
+    };
+    const callback = jest.fn();
+
+    render({ model, template }, callback);
+    test('should correctly return error', () => {
+      expect(callback).toBeCalledWith(
+        "The component can't be rendered because it was published with an older OC version"
+      );
+    });
+  });
   describe('when invoked with a valid template', () => {
     const model = { aModel: true };
     const template = {

--- a/packages/oc-template-jade/index.js
+++ b/packages/oc-template-jade/index.js
@@ -1,13 +1,16 @@
 'use strict';
 
-const { getInfo, render } = require('oc-generic-template-renderer');
-const getCompiledTemplate = require('./lib/getCompiledTemplate');
+const jade = require('jade-legacy/runtime.js');
+const renderer = require('oc-generic-template-renderer');
 const packageJson = require('./package.json');
+
+const context = { jade };
 
 module.exports = {
   getInfo() {
-    return getInfo(packageJson);
+    return renderer.getInfo(packageJson);
   },
-  getCompiledTemplate,
-  render
+  getCompiledTemplate: (templateString, key) =>
+    renderer.getCompiledTemplate(templateString, key, context),
+  render: renderer.render
 };

--- a/packages/oc-template-jade/lib/getCompiledTemplate.js
+++ b/packages/oc-template-jade/lib/getCompiledTemplate.js
@@ -1,8 +1,0 @@
-const jade = require('jade-legacy/runtime.js');
-const vm = require('vm');
-
-module.exports = (templateString, key) => {
-  const context = { jade };
-  vm.runInNewContext(templateString, context);
-  return context.oc.components[key];
-};

--- a/packages/oc-template-jade/test/getCompiledTemplate.test.js
+++ b/packages/oc-template-jade/test/getCompiledTemplate.test.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const getCompiledTemplate = require('../lib/getCompiledTemplate');
+const getCompiledTemplate = require('../').getCompiledTemplate;
 
 test('Return compiled template when valid', () => {
   const template =


### PR DESCRIPTION
…th node 4

affects: oc-generic-template-renderer, oc-template-handlebars, oc-template-jade

As shown here https://github.com/opencomponents/oc-client-node/pulls

I also took the chance to add a test and cleanup duplicated code.