### PR TITLE
Reusable webpack compiler

### DIFF
--- a/packages/oc-server-compiler/package.json
+++ b/packages/oc-server-compiler/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "async": "^2.4.1",
     "fs-extra": "^4.0.0",
+    "memory-fs": "^0.4.1",
     "oc-hash-builder": "1.0.1",
     "oc-webpack": "1.0.7"
   },

--- a/packages/oc-statics-compiler/package.json
+++ b/packages/oc-statics-compiler/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "oc-server-compiler",
-  "version": "1.0.1",
-  "description": "OC-Server-Compiler",
+  "name": "oc-statics-compiler",
+  "version": "1.0.0",
+  "description": "OC-Statics-Compiler",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -16,18 +16,22 @@
     "opencomponents"
   ],
   "author": {
-    "name": "Matteo Figus",
-    "email": "matteofigus@gmail.com"
+    "name": "Nick Balestra",
+    "email": "nick@balestra.ch"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4",
+    "async": "^2.4.1",
+    "fs-extra": "^3.0.1",
+    "oc-minify-file": "1.0.5",
+    "node-dir": "0.1.16",
+    "oc-templates-messages": "1.0.1"
   },
   "license": "MIT",
-  "dependencies": {
-    "async": "^2.4.1",
-    "fs-extra": "^4.0.0",
-    "memory-fs": "^0.4.1",
-    "oc-hash-builder": "1.0.1",
-    "oc-webpack": "1.0.8"
-  },
   "files": [
-    "index.js"
+    "LICENSE",
+    "README.md",
+    "index.js",
+    "lib"
   ]
 }

--- a/packages/oc-webpack/lib/compiler/index.js
+++ b/packages/oc-webpack/lib/compiler/index.js
@@ -37,11 +37,6 @@ module.exports = function compiler(config, callback) {
     if (log) {
       logger.log(log);
     }
-
-    const serverContentBundled = memoryFs.readFileSync(
-      '/build/server.js',
-      'UTF8'
-    );
-    callback(null, serverContentBundled);
+    callback(null, memoryFs.data);
   });
 };

--- a/packages/oc-webpack/test/oc-webpack.test.js
+++ b/packages/oc-webpack/test/oc-webpack.test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const api = require('../index.js');
 const webpackConfigurator = require('../lib/configurator');
 const webpackCompiler = require('../lib/compiler');
+const MemoryFS = require('memory-fs');
 
 test('module APIs', () => {
   expect(api).toMatchSnapshot();
@@ -44,7 +45,9 @@ test('webpack compiler', done => {
     )
   });
 
-  webpackCompiler(config, (error, serverContentBundled) => {
+  webpackCompiler(config, (error, data) => {
+    const fs = new MemoryFS(data);
+    const serverContentBundled = fs.readFileSync('/build/server.js', 'UTF8');
     expect(serverContentBundled).toMatchSnapshot();
     done();
   });
@@ -64,7 +67,9 @@ test('webpack compiler verbose', done => {
     )
   });
 
-  webpackCompiler(config, (error, serverContentBundled) => {
+  webpackCompiler(config, (error, data) => {
+    const fs = new MemoryFS(data);
+    const serverContentBundled = fs.readFileSync('/build/server.js', 'UTF8');
     const consoleOutput = loggerMock.log.mock.calls[0][0];
     expect(serverContentBundled).toMatchSnapshot();
     expect(consoleOutput).toMatch(/Hash:(.*?)01e93c95dfecf93de280/);
@@ -92,7 +97,7 @@ test('webpack compiler with fatal error', done => {
     );
   });
 
-  webpackCompiler(config, (error, serverContentBundled) => {
+  webpackCompiler(config, (error, data) => {
     expect(error).toMatchSnapshot();
     done();
   });
@@ -106,7 +111,7 @@ test('webpack compiler with soft error', done => {
     serverPath: path.join(__dirname, 'some/not/valid/path', 'server.js')
   });
 
-  webpackCompiler(config, (error, serverContentBundled) => {
+  webpackCompiler(config, (error, data) => {
     expect(error).toContain(`Entry module not found: Error: Can't resolve`);
     done();
   });
@@ -131,7 +136,7 @@ test('webpack compiler with warning', done => {
     this.plugin('done', stats => stats.compilation.warnings.push('A warning'));
   });
 
-  webpackCompiler(config, (error, serverContentBundled) => {
+  webpackCompiler(config, (error, data) => {
     expect(loggerMock.log.mock.calls[0][0]).toContain('A warning');
     expect(error).toBe(null);
     done();


### PR DESCRIPTION
Webpack compiler now returns the inmemory object used during compilation

affects: oc-server-compiler, oc-webpack

This allows the oc-webpack compiler to support multiple cases (ie: when multiple file are generated,
as its the case for css with textExtract, ...). The output tight anymore to server.js file being
processed but can be used for anything.

BREAKING CHANGE:
Compilers relyin gon this now have to access the memory object themselves

ISSUES CLOSED: #50