### PR TITLE
Ensure __ITER var is always defined inside enclosing block

### DIFF
--- a/packages/infinite-loop-loader/lib/transformLoopWithLimit.js
+++ b/packages/infinite-loop-loader/lib/transformLoopWithLimit.js
@@ -17,10 +17,17 @@ module.exports = limit => {
     node.type === 'BlockStatement' &&
     loopNodeTypes.indexOf(node.parent.type) > -1;
 
-  const addVarDeclarationBeforeNode = (node, limit) =>
+  const addVarDeclarationBeforeNode = (node, limit) => {
     node.update(`
       var __ITER = ${limit};
       ${node.source()}`);
+
+    if (node.parent && node.parent.consequent !== undefined) {
+      node.update(`{
+        ${node.source()}
+      }`);
+    }
+  };
 
   const addGuardsToLoopBody = node =>
     node.update(

--- a/packages/infinite-loop-loader/test/__snapshots__/infinite-loop-loader.spec.js.snap
+++ b/packages/infinite-loop-loader/test/__snapshots__/infinite-loop-loader.spec.js.snap
@@ -68,6 +68,25 @@ module.exports.data = function(context, cb) {
     z = 342;
   } while(false);
   return cb(null, data)
+ 
+  if (false) {
+        
+      var __ITER = 1000000000;
+      while (true) { if (__ITER <= 0) {
+        throw new Error(\\"Loop exceeded maximum allowed iterations\\");
+      }
+      __ITER--;
+      }
+      }
+  else {
+        
+      var __ITER = 1000000000;
+      while (true) { if (__ITER <= 0) {
+        throw new Error(\\"Loop exceeded maximum allowed iterations\\");
+      }
+      __ITER--;
+      }
+      }
 };
 "
 `;

--- a/packages/infinite-loop-loader/test/infinite-loop-loader.spec.js
+++ b/packages/infinite-loop-loader/test/infinite-loop-loader.spec.js
@@ -41,6 +41,9 @@ module.exports.data = function(context, cb) {
     z = 342;
   } while(false);
   return cb(null, data)
+ 
+  if (false) while (true) {}
+  else while (true) {}
 };
 `;
     const result = loader(source);


### PR DESCRIPTION
affects: infinite-loop-loader

Fixes issue where __ITER var was defined without being inside a block when loop parents were
shorthand syntax conditionals/loops

ISSUES CLOSED: 58