### PR TITLE
fix(dependendencies): updated to to latest infinite-loop-loader

### DIFF
--- a/packages/oc-webpack/package.json
+++ b/packages/oc-webpack/package.json
@@ -27,7 +27,7 @@
     "babel-loader": "^7.0.0",
     "babel-preset-env": "^1.5.2",
     "babili-webpack-plugin": "^0.1.1",
-    "infinite-loop-loader": "^1.0.3",
+    "infinite-loop-loader": "^1.0.4",
     "memory-fs": "^0.4.1",
     "oc-external-dependencies-handler": "^1.0.3",
     "webpack": "^2.6.1"


### PR DESCRIPTION
affects: oc-webpack

ISSUES CLOSED: #58 

@matteofigus the `oc-webpack` package wasn't updated & released automatically due to this change (while infinite loop loader was). Is this because `infinite-loop-loader` is set as `^` instead of exact?