### PR TITLE
chore: commit validation will fail with bots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,5 @@ matrix:
 after_script:
   - npm run coverage
 
-script:
-  - validate-commit-msg "$(git log -1 --pretty=%B)" && npm test
-
 notifications:
   email: false


### PR DESCRIPTION
Had to disable running validation for commits on ci cause each time a bot will die 