### PR TITLE
[DX-263] - no sideffects from a root .babelrc

### DIFF
--- a/packages/oc-webpack/lib/configurator/index.js
+++ b/packages/oc-webpack/lib/configurator/index.js
@@ -29,6 +29,7 @@ module.exports = function webpackConfigGenerator(options) {
               loader: require.resolve('babel-loader'),
               options: {
                 cacheDirectory: true,
+                babelrc: false,
                 presets: [
                   [
                     require.resolve('babel-preset-env'),

--- a/packages/oc-webpack/test/__snapshots__/oc-webpack.test.js.snap
+++ b/packages/oc-webpack/test/__snapshots__/oc-webpack.test.js.snap
@@ -33,6 +33,7 @@ Object {
           Object {
             "loader": "../node_modules/babel-loader/lib/index.js",
             "options": Object {
+              "babelrc": false,
               "cacheDirectory": true,
               "presets": Array [
                 Array [


### PR DESCRIPTION
Address https://github.com/opentable/oc/issues/611

By making sure we babel-loader doesnt inherit settings from a .babelrc file (as per https://github.com/babel/babel/issues/6607#issuecomment-340489039)
