### PR TITLE
44% Speed Improvement for CI Builds times

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "prettier-eslint-cli": "^4.1.1"
   },
   "scripts": {
-    "clean": "lerna clean",
+    "clean": "lerna clean && rm -rf node_modules/",
     "coverage": "codecov",
     "dev": "jest --watch",
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna bootstrap --hoist",
     "precommit": "lint-staged",
     "publish": "lerna publish --exact",
     "test": "jest",

--- a/packages/oc-minify-file/package.json
+++ b/packages/oc-minify-file/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "babel-core": "^6.25.0",
-    "babel-preset-env": "^1.5.2",
+    "babel-preset-env": "^1.6.1",
     "clean-css": "^4.1.4",
     "oc-templates-messages": "1.0.1",
     "uglify-js": "3.3.9"

--- a/packages/oc-webpack/package.json
+++ b/packages/oc-webpack/package.json
@@ -27,7 +27,7 @@
     "babel-loader": "^7.1.2",
     "babel-minify-webpack-plugin": "^0.2.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.6.0",
+    "babel-preset-env": "^1.6.1",
     "infinite-loop-loader": "1.0.5",
     "memory-fs": "^0.4.1",
     "oc-external-dependencies-handler": "1.0.5",

--- a/packages/oc-webpack/test/__snapshots__/oc-webpack.test.js.snap
+++ b/packages/oc-webpack/test/__snapshots__/oc-webpack.test.js.snap
@@ -31,18 +31,18 @@ Object {
             "loader": "../../infinite-loop-loader/index.js",
           },
           Object {
-            "loader": "../node_modules/babel-loader/lib/index.js",
+            "loader": "../../../node_modules/babel-loader/lib/index.js",
             "options": Object {
               "babelrc": false,
               "cacheDirectory": true,
               "plugins": Array [
                 Array [
-                  "../node_modules/babel-plugin-transform-object-rest-spread/lib/index.js",
+                  "../../../node_modules/babel-plugin-transform-object-rest-spread/lib/index.js",
                 ],
               ],
               "presets": Array [
                 Array [
-                  "../node_modules/babel-preset-env/lib/index.js",
+                  "../../../node_modules/babel-preset-env/lib/index.js",
                   Object {
                     "modules": false,
                     "targets": Object {


### PR DESCRIPTION
This PR rely on [lerna hoisting](https://github.com/lerna/lerna/blob/master/doc/hoist.md), to reduce bootstrap times on a 44% fold:

no hoisting (current situation)
```
added 1272 packages in 55.317s
```
hoisting (situation after this PR)
```
added 1272 packages in 31.12s
```
Couple of nice sideffects:
- while hoisting if two packages rely on a different version of the same dependencies, lerna will warn you. For example I was able to find that oc-template-minify and oc-webpack rely on a different version of the env preset...(see this pr)
- As shared deps are now hoisted, will allow us to rely on CI caching for node_modules to drastically decrease CI testing times even further (follow-up pr to come)
