### PR TITLE
[DX-412] Empty response module

### DIFF
--- a/packages/oc-empty-response-handler/LICENSE
+++ b/packages/oc-empty-response-handler/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 OpenComponents community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/oc-empty-response-handler/README.md
+++ b/packages/oc-empty-response-handler/README.md
@@ -1,0 +1,3 @@
+# oc-empty-response-handler
+
+Handler for the empty response use case

--- a/packages/oc-empty-response-handler/index.js
+++ b/packages/oc-empty-response-handler/index.js
@@ -1,0 +1,8 @@
+const viewModelEmptyKey = '__oc_emptyResponse';
+
+module.exports = {
+  contextDecorator: callback => () =>
+    callback(null, { [viewModelEmptyKey]: true }),
+  shouldRenderAsEmpty: model => model[viewModelEmptyKey] === true,
+  viewModelEmptyKey
+};

--- a/packages/oc-empty-response-handler/package.json
+++ b/packages/oc-empty-response-handler/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "oc-empty-response-handler",
+  "version": "0.0.1",
+  "description": "Handler for the empty response use case",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opencomponents/base-templates.git"
+  },
+  "bugs": {
+    "url": "https://github.com/opencomponents/base-templates/issues"
+  },
+  "homepage": "https://github.com/opencomponents/base-templates#readme",
+  "keywords": ["oc", "opencomponents"],
+  "author": {
+    "name": "Matteo Figus",
+    "email": "matteofigus@gmail.com"
+  },
+  "license": "MIT",
+  "files": ["index.js", "README.md", "LICENSE"]
+}

--- a/packages/oc-empty-response-handler/test/oc-empty-response-handler.test.js
+++ b/packages/oc-empty-response-handler/test/oc-empty-response-handler.test.js
@@ -1,0 +1,40 @@
+const emptyResponseHandler = require('../index.js');
+
+test('context decorator called', () => {
+  const context = {};
+  const callback = jest.fn();
+  context.setEmptyResponse = emptyResponseHandler.contextDecorator(callback);
+
+  context.setEmptyResponse();
+  expect(callback).toBeCalledWith(null, { __oc_emptyResponse: true });
+});
+
+test('context decorator not called', () => {
+  const context = {};
+  const callback = jest.fn();
+  context.setEmptyResponse = emptyResponseHandler.contextDecorator(callback);
+
+  callback(null, { myViewModel: 'test' });
+  expect(callback).toBeCalledWith(null, { myViewModel: 'test' });
+});
+
+describe('renderer', () => {
+  const scenarios = [
+    { model: { __oc_emptyResponse: true }, expected: '' },
+    { model: { name: 'test' }, expected: '<p>test</p>' },
+    { model: { __oc_emptyResponse: false }, expected: '<p></p>' }
+  ];
+
+  const template = model => `<p>${model.name || ''}</p>`;
+
+  const render = model => {
+    const empty = emptyResponseHandler.shouldRenderAsEmpty(model);
+    return empty ? '' : template(model);
+  };
+
+  scenarios.forEach(scenario =>
+    test(`when model=${JSON.stringify(scenario.model)}`, () => {
+      expect(render(scenario.model)).toEqual(scenario.expected);
+    })
+  );
+});


### PR DESCRIPTION
The goal here is to have in a unique module all the loglic around this new feature:
1) The context decorator for the registry
2) An utility to be used inside node/browser renderers for the rendering logic

In this way, all the clients/server can rely on a unique module.

Depends on #278 + rebase