### PR TITLE
Unable to load proxied external npm dependencies

### DIFF
--- a/packages/oc-external-dependencies-handler/index.js
+++ b/packages/oc-external-dependencies-handler/index.js
@@ -6,7 +6,7 @@
  * bundled by webPack but instead remain requested by the resulting bundle.
  * For more info http://webpack.github.io/docs/configuration.html#externals
  *
-*/
+ */
 
 const coreModules = require('builtin-modules');
 const strings = require('oc-templates-messages');
@@ -24,7 +24,7 @@ module.exports = dependencies => {
     (context, req, callback) => {
       if (matcher.test(req)) {
         let dependencyName = req;
-        if (/\//g.test(dependencyName)) {
+        if (/^(?!@).*\//g.test(dependencyName)) {
           dependencyName = dependencyName.substring(
             0,
             dependencyName.indexOf('/')

--- a/packages/oc-external-dependencies-handler/test/oc-external-dependencies-handler.test.js
+++ b/packages/oc-external-dependencies-handler/test/oc-external-dependencies-handler.test.js
@@ -64,3 +64,15 @@ test('The handler matcher should correctly match aganinst not valid modules', ()
   expect(handlerMatcher.test('./myModule.json')).toBe(false);
   expect(handlerMatcher.test('./myModule.js')).toBe(false);
 });
+
+test('Module declared with @org_namespace/module_name in the package is also allowed (proxied npm registry)', done => {
+  const handler = externalDependenciesHandler({
+    '@org/proxied-lodash': '4.17.4'
+  });
+  const handlerFunction = handler[0];
+
+  handlerFunction(null, '@org/proxied-lodash', err => {
+    expect(err).toBeUndefined();
+    done();
+  });
+});


### PR DESCRIPTION
In cases where we need to load dependencies from proxied setup using
tools like verdaccio, OC dev server start fails with "Module not found: Error: Missing dependencies from package.json".
In all proxied setup people generally namespace them using '@' in the
start. Exmaple: @chegg/oc-helper. Hence updated regex to take out
substring (anything comes after forward slash '/') only if dep-name won't have @ in front it.

Signed-Off-By: Tushar Kant <tushar@chegg.com>