### PR TITLE
Update handlebars to latest

### DIFF
--- a/packages/oc-template-handlebars/package.json
+++ b/packages/oc-template-handlebars/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "handlebars": "^4.5.3",
+    "handlebars": "4.5.3",
     "nice-cache": "0.0.5",
     "oc-generic-template-renderer": "2.0.4",
     "oc-templates-messages": "1.0.2"

--- a/packages/oc-template-handlebars/package.json
+++ b/packages/oc-template-handlebars/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "handlebars": "4.1.2",
+    "handlebars": "^4.5.3",
     "nice-cache": "0.0.5",
     "oc-generic-template-renderer": "2.0.4",
     "oc-templates-messages": "1.0.2"

--- a/packages/oc-template-handlebars/test/__snapshots__/getInfo.test.js.snap
+++ b/packages/oc-template-handlebars/test/__snapshots__/getInfo.test.js.snap
@@ -6,7 +6,7 @@ Object {
     Object {
       "global": "Handlebars",
       "name": "handlebars",
-      "url": "https://unpkg.com/handlebars@6.6.6/dist/handlebars.runtime.min.js",
+      "url": "https://unpkg.com/handlebars@4.1.2/dist/handlebars.runtime.min.js",
     },
   ],
   "type": "oc-template-handlebars",


### PR DESCRIPTION
This PR updates the handlebars dependency to the latest version to avoid security vulnerabilities.