### PR TITLE
Update webpack version

### DIFF
--- a/packages/oc-server-compiler/package.json
+++ b/packages/oc-server-compiler/package.json
@@ -32,7 +32,7 @@
     "memory-fs": "^0.4.1",
     "oc-external-dependencies-handler": "1.0.8",
     "oc-hash-builder": "1.0.2",
-    "webpack": "^4.8.3"
+    "webpack": "^4.43.0"
   },
   "files": [
     "lib/**/*",

--- a/packages/oc-template-es6-compiler/package.json
+++ b/packages/oc-template-es6-compiler/package.json
@@ -44,7 +44,7 @@
     "postcss-icss-values": "^2.0.1",
     "postcss-import": "12.0.1",
     "postcss-loader": "3.0.0",
-    "webpack": "^4.8.3"
+    "webpack": "^4.43.0"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
This version of webpack does not contain some security updates and causes vulnerabilities. 
Update webpack major version to get security updates in the latest version.