### PR TITLE
[SFX-2153] - Downgrade Handlebars Compiler

### DIFF
--- a/packages/oc-template-handlebars-compiler/package.json
+++ b/packages/oc-template-handlebars-compiler/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "async": "^2.4.1",
     "fs-extra": "8.1.0",
-    "handlebars": "4.7.2",
+    "handlebars": "4.1.2",
     "oc-generic-template-compiler": "2.0.6",
     "oc-hash-builder": "1.0.2",
     "oc-server-compiler": "2.1.8",

--- a/packages/oc-template-handlebars-compiler/test/__snapshots__/compileView.test.js.snap
+++ b/packages/oc-template-handlebars-compiler/test/__snapshots__/compileView.test.js.snap
@@ -10,7 +10,7 @@ Object {
 }
 `;
 
-exports[`Should correctly compile the view 2`] = `"var oc=oc||{};oc.components=oc.components||{},oc.components[\\"dummyData\\"]={compiler:[8,\\">= 4.3.0\\"],main:function(c,o,e,n,a){return\\"<h1>Hello handlebars!</h1>\\"},useData:!0};"`;
+exports[`Should correctly compile the view 2`] = `"var oc=oc||{};oc.components=oc.components||{},oc.components[\\"dummyData\\"]={compiler:[7,\\">= 4.0.0\\"],main:function(c,o,e,n,a){return\\"<h1>Hello handlebars!</h1>\\"},useData:!0};"`;
 
 exports[`When compiled view writing fails should return error 1`] = `"template.hbs compilation failed - sorry I failed"`;
 


### PR DESCRIPTION
Hi,

I'm trying to upgrade the version of handlebars again, by initially downgrading the compiler :)

The issue that we were running into previously has been run into by others:

- https://github.com/handlebars-lang/handlebars.js/issues/1561

From reading the issues and looking at the following subsequent commit it looks like the handlebars team has fixed the issue:

- https://github.com/handlebars-lang/handlebars.js/commit/12668388294ee8bb1c07c0d9d5c6ee083910f3a5#diff-cccd9fbbd9d8ac0bff571e9c8b0ee9deR10

Why am I downgrading the version of the compiler? Because from what I understand I need to do this as a two-step process we cannot upgrade the compiler and the render at the same time as the previous PR attempted. 