### PR TITLE
Update handlebars dependency to 4.7.6

### DIFF
--- a/packages/oc-template-handlebars-compiler/package.json
+++ b/packages/oc-template-handlebars-compiler/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "async": "^2.4.1",
     "fs-extra": "8.1.0",
-    "handlebars": "4.1.2",
+    "handlebars": "4.7.6",
     "oc-generic-template-compiler": "2.0.6",
     "oc-hash-builder": "1.0.2",
     "oc-server-compiler": "2.1.8",

--- a/packages/oc-template-handlebars-compiler/test/__snapshots__/compileView.test.js.snap
+++ b/packages/oc-template-handlebars-compiler/test/__snapshots__/compileView.test.js.snap
@@ -10,7 +10,7 @@ Object {
 }
 `;
 
-exports[`Should correctly compile the view 2`] = `"var oc=oc||{};oc.components=oc.components||{},oc.components[\\"dummyData\\"]={compiler:[7,\\">= 4.0.0\\"],main:function(c,o,e,n,a){return\\"<h1>Hello handlebars!</h1>\\"},useData:!0};"`;
+exports[`Should correctly compile the view 2`] = `"var oc=oc||{};oc.components=oc.components||{},oc.components[\\"dummyData\\"]={compiler:[8,\\">= 4.3.0\\"],main:function(c,o,e,n,a){return\\"<h1>Hello handlebars!</h1>\\"},useData:!0};"`;
 
 exports[`When compiled view writing fails should return error 1`] = `"template.hbs compilation failed - sorry I failed"`;
 

--- a/packages/oc-template-handlebars/package.json
+++ b/packages/oc-template-handlebars/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "handlebars": "4.1.2",
+    "handlebars": "4.7.6",
     "nice-cache": "0.0.5",
     "oc-generic-template-renderer": "2.0.4",
     "oc-templates-messages": "1.0.2"
@@ -35,7 +35,7 @@
   "externals": {
     "handlebars": {
       "global": "Handlebars",
-      "url": "https://unpkg.com/handlebars@4.7.2/dist/handlebars.runtime.min.js"
+      "url": "https://unpkg.com/handlebars@4.7.6/dist/handlebars.runtime.min.js"
     }
   }
 }

--- a/packages/oc-template-handlebars/test/__snapshots__/getInfo.test.js.snap
+++ b/packages/oc-template-handlebars/test/__snapshots__/getInfo.test.js.snap
@@ -6,7 +6,7 @@ Object {
     Object {
       "global": "Handlebars",
       "name": "handlebars",
-      "url": "https://unpkg.com/handlebars@4.7.2/dist/handlebars.runtime.min.js",
+      "url": "https://unpkg.com/handlebars@6.6.6/dist/handlebars.runtime.min.js",
     },
   ],
   "type": "oc-template-handlebars",


### PR DESCRIPTION
Updated handlebars for:
- the external dependency url
- the package dependency version
- snapshots