### PR TITLE
add ts-typings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,16 +1,24 @@
 {
+  "parser": "@typescript-eslint/parser",
   "env": {
     "es6": true,
     "node": true
   },
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "parserOptions": {
+    "ecmaVersion": 2018
+  },
   "rules": {
     "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
-    "quotes": ["error", "single", {
-      "avoidEscape": true,
-      "allowTemplateLiterals": true
-    }],
+    "quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }
+    ],
     "semi": ["error", "always"],
     "no-var": "error",
     "strict": ["error", "safe"]

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "lerna": "2.4.0",
   "packages": ["packages/*", "acceptance-setup", "acceptance-components/*"],
   "version": "independent",
-  "npmClient": "npm",
+  "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,11 +1,7 @@
 {
   "lerna": "2.4.0",
-  "packages": [
-    "packages/*",
-    "acceptance-setup",
-    "acceptance-components/*"
-  ],
+  "packages": ["packages/*", "acceptance-setup", "acceptance-components/*"],
   "version": "independent",
-  "npmClient": "yarn",
+  "npmClient": "npm",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "private": true,
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.31.0",
+    "@typescript-eslint/parser": "^4.31.0",
     "codecov": "3.7.1",
     "husky": "3.0.8",
     "jest": "24.9.0",
@@ -9,7 +11,8 @@
     "lint-staged": "9.4.1",
     "node-dir": "0.1.17",
     "oc": "0.48.12",
-    "prettier-eslint-cli": "5.0.0"
+    "prettier-eslint-cli": "5.0.0",
+    "typescript": "^4.4.2"
   },
   "scripts": {
     "clean": "lerna clean && rm -rf node_modules",

--- a/packages/infinite-loop-loader/index.d.ts
+++ b/packages/infinite-loop-loader/index.d.ts
@@ -1,0 +1,3 @@
+declare const infiniteLoopLoader: (source: string) => string;
+
+export = infiniteLoopLoader;

--- a/packages/infinite-loop-loader/package.json
+++ b/packages/infinite-loop-loader/package.json
@@ -8,6 +8,7 @@
   },
   "license": "MIT",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/base-templates.git"

--- a/packages/oc-empty-response-handler/index.d.ts
+++ b/packages/oc-empty-response-handler/index.d.ts
@@ -1,0 +1,9 @@
+type Callback<T = unknown> = (err: Error | null, data: T) => void;
+
+declare const emptyResponseHandler: {
+  contextDecorator: (cb: Callback) => () => void;
+  shouldRenderAsEmpty: (model: any) => boolean;
+  viewModelEmptyKey: string;
+};
+
+export = emptyResponseHandler;

--- a/packages/oc-empty-response-handler/package.json
+++ b/packages/oc-empty-response-handler/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Handler for the empty response use case",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/base-templates.git"

--- a/packages/oc-external-dependencies-handler/index.d.ts
+++ b/packages/oc-external-dependencies-handler/index.d.ts
@@ -1,0 +1,5 @@
+import type { Configuration } from 'webpack';
+
+declare const externalDependenciesHandler: (dependencies: Record<string, string>) => Configuration['externals'];
+
+export = externalDependenciesHandler;

--- a/packages/oc-external-dependencies-handler/package.json
+++ b/packages/oc-external-dependencies-handler/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.8",
   "description": "External dependencies handler for webpack",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/base-templates.git"
@@ -29,5 +30,8 @@
     "builtin-modules": "3.1.0",
     "lodash": "^4.17.4",
     "oc-templates-messages": "1.0.2"
+  },
+  "devDependencies": {
+    "webpack": "^5.52.0"
   }
 }

--- a/packages/oc-generic-template-compiler/index.d.ts
+++ b/packages/oc-generic-template-compiler/index.d.ts
@@ -1,0 +1,68 @@
+type Callback<T = unknown> = (err: Error | null, data: T) => void;
+
+interface PackageJson {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+interface CompiledViewInfo {
+  template: {
+    type: string;
+    hashKey: string;
+    src: string;
+  };
+  bundle: { hashKey: string };
+}
+
+type OcOptions = {
+  files: {
+    data: string;
+    template: {
+      src: string;
+      type: string;
+    };
+    static: string[];
+  };
+};
+
+interface CompilerOptions {
+  componentPackage: PackageJson & {
+    oc: OcOptions;
+  };
+  componentPath: string;
+  minify: boolean;
+  ocPackage: PackageJson;
+  production: boolean;
+  publishPath: string;
+  verbose: boolean;
+  watch: boolean;
+}
+
+type CompileView = (options: CompilerOptions, cb: Callback<CompiledViewInfo>) => void;
+type CompileServer = (
+  options: CompilerOptions & { compiledViewInfo: CompiledViewInfo },
+  cb: Callback<any>
+) => void;
+type CompileStatics = (options: CompilerOptions, cb: Callback<'ok'>) => void;
+type GetInfo = () => {
+  type: string;
+  version: string;
+  externals: Array<{
+    name: string;
+    global: string | string[];
+    url: string;
+  }>;
+};
+
+declare const compiler: {
+  createCompile: (compilers: {
+    compileView: CompileView;
+    compileServer: CompileServer;
+    compileStatics: CompileStatics;
+    getInfo: GetInfo;
+  }) => (options: CompilerOptions, cb: Callback) => void;
+};
+
+export = compiler;

--- a/packages/oc-generic-template-compiler/package.json
+++ b/packages/oc-generic-template-compiler/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.6",
   "description": "OC-Generic-Template-Compiler",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/base-templates.git"

--- a/packages/oc-generic-template-renderer/index.d.ts
+++ b/packages/oc-generic-template-renderer/index.d.ts
@@ -1,0 +1,27 @@
+export interface External {
+  global: string | string[];
+  url: string;
+}
+
+export interface ExternalInfo extends External {
+  name: string;
+}
+
+type Callback<T = unknown> = (err: Error | null, data: T) => void;
+type CompiledTemplate = (model: unknown) => string;
+
+declare const renderer: {
+  getCompiledTemplate: (
+    templateString: string,
+    key: string,
+    context: Record<string, unknown>
+  ) => CompiledTemplate;
+  getInfo: (package: {
+    name: string;
+    version: string;
+    externals?: Record<string, External>;
+  }) => { type: string; version: string; externals: Array<ExternalInfo> };
+  render: (options: { model: unknown; template: CompiledTemplate }, cb: Callback<string>) => void;
+};
+
+export = renderer;

--- a/packages/oc-generic-template-renderer/package.json
+++ b/packages/oc-generic-template-renderer/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.5",
   "description": "OC-Generic-Template-Renderer",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/base-templates.git"

--- a/packages/oc-get-unix-utc-timestamp/index.d.ts
+++ b/packages/oc-get-unix-utc-timestamp/index.d.ts
@@ -1,0 +1,3 @@
+declare const getUnixUtcTimestamp: () => number;
+
+export = getUnixUtcTimestamp;

--- a/packages/oc-get-unix-utc-timestamp/package.json
+++ b/packages/oc-get-unix-utc-timestamp/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "UTC times stamp utility",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/base-templates.git"

--- a/packages/oc-hash-builder/index.d.ts
+++ b/packages/oc-hash-builder/index.d.ts
@@ -1,0 +1,5 @@
+declare const hashBuilder: {
+  fromString: (content: string) => string;
+};
+
+export = hashBuilder;

--- a/packages/oc-hash-builder/package.json
+++ b/packages/oc-hash-builder/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "Hash builder utility",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/base-templates.git"

--- a/packages/oc-minify-file/index.d.ts
+++ b/packages/oc-minify-file/index.d.ts
@@ -1,0 +1,3 @@
+declare const minify: (fileExtension: string, fileContent: string) => string;
+
+export = minify;

--- a/packages/oc-minify-file/package.json
+++ b/packages/oc-minify-file/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.16",
   "description": "Minify file helper",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/base-templates.git"

--- a/packages/oc-templates-messages/index.d.ts
+++ b/packages/oc-templates-messages/index.d.ts
@@ -1,0 +1,14 @@
+declare const messages: {
+  errors: {
+    compilationFailed: (viewFileName: string, error: string) => string;
+    cssNotValid: () => string;
+    folderNotFound: (directoryPath: string) => string;
+    folderNotValid: (directoryPath: string) => string;
+    legacyComponent: () => string;
+    loopExceededIterations: () => string;
+    missingDependency: (dependencyName: string) => string;
+    viewNotFound: (viewFileName: string) => string;
+  };
+};
+
+export = messages;

--- a/packages/oc-templates-messages/package.json
+++ b/packages/oc-templates-messages/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "OC-Templates-Messages",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/oc-templates-messages.git"

--- a/packages/oc-view-wrapper/index.d.ts
+++ b/packages/oc-view-wrapper/index.d.ts
@@ -1,0 +1,3 @@
+declare const viewWrapper: (hash: string, content: string, namespace?: string) => string;
+
+export = viewWrapper;

--- a/packages/oc-view-wrapper/package.json
+++ b/packages/oc-view-wrapper/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.3",
   "description": "Wrapper helper for oc views",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/opencomponents/base-templates.git"


### PR DESCRIPTION
This adds Typescript typings to all projects except the non-generic compilers (those will be added when the generic one is published so types can be reused)