### PR TITLE
Fix scoped module detection logic & add regression test

### DIFF
--- a/packages/oc-external-dependencies-handler/index.js
+++ b/packages/oc-external-dependencies-handler/index.js
@@ -12,6 +12,11 @@ const coreModules = require('builtin-modules');
 const strings = require('oc-templates-messages');
 const _ = require('lodash');
 
+function getPosition(string, subString, index) {
+  return string.split(subString, index).join(subString).length;
+}
+
+
 module.exports = dependencies => {
   const deps = dependencies || {};
 
@@ -28,6 +33,12 @@ module.exports = dependencies => {
           dependencyName = dependencyName.substring(
             0,
             dependencyName.indexOf('/')
+          );
+        }
+        if (/^(@).*\//g.test(dependencyName)) {
+          dependencyName = dependencyName.substring(
+            0,
+            getPosition(dependencyName, "/", 2)
           );
         }
         if (missingExternalDependency(dependencyName, deps)) {

--- a/packages/oc-external-dependencies-handler/test/oc-external-dependencies-handler.test.js
+++ b/packages/oc-external-dependencies-handler/test/oc-external-dependencies-handler.test.js
@@ -55,6 +55,16 @@ test('The handler matcher should correctly match aganinst valid modules', () => 
   expect(handlerMatcher.test('@org/module/path')).toBe(true);
 });
 
+test('The handler function should detect valid scoped modules that import paths', (done) => {
+  const handler = externalDependenciesHandler({ lodash: '4.17.4', "@org/module": '1.0.0' });
+  const handlerFunction = handler[0];
+
+  handlerFunction({ request: '@org/module/path' }, err => {
+    expect(err).toBeUndefined();
+    done();
+  });
+});
+
 test('The handler matcher should correctly match aganinst not valid modules', () => {
   const handler = externalDependenciesHandler({ lodash: '4.17.4' });
   const handlerMatcher = handler[1];


### PR DESCRIPTION
# Bug description: 

When loading a module that has the form `@org/module/path` within `server.js` OC framework fails to identify that this module _is_ installed and defined within package.json. Note that there is no problem with module imports of the form: `module/path`. 

# Solution:

In this PR I add a very similar block to specifically deal with scoped imports. In this block the module name is detected by selecting from the second `/` appearing in the `request/dep`. 

I've also included a test to ensure that this new code works as expected. 